### PR TITLE
on_error() decorator added

### DIFF
--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -25,3 +25,4 @@ from .message_handler import MessageHandler
 from .poll_handler import PollHandler
 from .raw_update_handler import RawUpdateHandler
 from .user_status_handler import UserStatusHandler
+from .error_handler import ErrorHandler

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -1,0 +1,74 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-2021 Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import asyncio
+
+from pyrogram import errors
+
+
+class ErrorHandler:
+    """The Error handler class. Used to handle errors which coming from Telegram server - RPCError and python exceptions
+    which inherits from BaseException as well. It is intended to be used with :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_error` decorator.
+
+    Parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself
+
+        catch_all (`bool`, *optional*):
+            This tells whether to catch python exceptions as well or not.
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself, useful when you want to call other API methods inside the error handler.
+
+        exception (:obj:`BaseException`):
+            The raised exception itself.
+
+    """
+
+    original_run_in_executor = asyncio.BaseEventLoop.run_in_executor
+    origin_except_hook = sys.excepthook
+
+    def __init__(self, client, callback: callable, catch_all: bool = False):
+        self.client = client
+        self.callback = callback
+        self.exceptions_to_catch = [errors.RPCError]
+
+        if catch_all:
+            self.exceptions_to_catch.append(BaseException)
+            sys.excepthook = self.except_hook
+
+        asyncio.BaseEventLoop.run_in_executor = self.run_in_executor
+
+    async def run_in_executor(self, *args, **kwargs):
+        try:
+            result = await self.original_run_in_executor(*args, **kwargs)
+        except self.exceptions_to_catch as exc:
+            self.callback(self.client, exc[1])
+        else:
+            return result
+
+    def except_hook(self, *args):
+        try:
+            self.callback(self.client, args[1])
+        except BaseException:
+            self.origin_except_hook(*sys.exc_info())

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -16,28 +16,33 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from .on_callback_query import OnCallbackQuery
-from .on_chosen_inline_result import OnChosenInlineResult
-from .on_deleted_messages import OnDeletedMessages
-from .on_disconnect import OnDisconnect
-from .on_inline_query import OnInlineQuery
-from .on_message import OnMessage
-from .on_poll import OnPoll
-from .on_raw_update import OnRawUpdate
-from .on_user_status import OnUserStatus
-from .on_error import OnError
+
+from typing import Callable
+
+import pyrogram
+from pyrogram.scaffold import Scaffold
 
 
-class Decorators(
-    OnMessage,
-    OnDeletedMessages,
-    OnCallbackQuery,
-    OnRawUpdate,
-    OnDisconnect,
-    OnUserStatus,
-    OnInlineQuery,
-    OnPoll,
-    OnChosenInlineResult,
-    OnError
-):
-    pass
+class OnError(Scaffold):
+    def on_error(
+        self=None,
+        catch_all: bool = False,
+    ) -> callable:
+        """Decorator for handling errors.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.ErrorHandler`.
+
+        Parameters:
+            catch_all (`bool`, *optional*):
+                Pass true in order to catch every error (not only RPCError) on your app.
+
+        """
+
+        def decorator(function: Callable) -> Callable:
+            self.add_handler(
+                pyrogram.handlers.error_handler.ErrorHandler(self, function, catch_all)
+            )
+            return function
+
+        return decorator

--- a/pyrogram/methods/utilities/add_handler.py
+++ b/pyrogram/methods/utilities/add_handler.py
@@ -18,11 +18,14 @@
 
 from pyrogram.handlers import DisconnectHandler
 from pyrogram.handlers.handler import Handler
+from pyrogram.handlers.error_handler import ErrorHandler
 from pyrogram.scaffold import Scaffold
+
+from typing import Union
 
 
 class AddHandler(Scaffold):
-    def add_handler(self, handler: "Handler", group: int = 0):
+    def add_handler(self, handler: Union["Handler", "ErrorHandler"], group: int = 0):
         """Register an update handler.
 
         You can register multiple handlers, but at most one handler within a group will be used for a single update.


### PR DESCRIPTION
a new on_error decorator has been added.
you can use it via

@on_error()
def error_handler(client, exception_object):
    pass

or

@on_error(check_all=True)
def error_handler(client, exception_object):
    pass

In order to catch all errors raised on application, not only RPCErrors.