### PR TITLE
Fix stackable plugin decorators with include/exclude directives (#643)

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -724,7 +724,7 @@ class Client(Methods, Scaffold):
                                     log.info('[{}] [LOAD] {}("{}") in group {} from "{}"'.format(
                                         self.session_name, type(handler).__name__, name, group, module_path))
 
-                                count += 1
+                                    count += 1
                         except Exception:
                             pass
             else:
@@ -749,15 +749,14 @@ class Client(Methods, Scaffold):
                     for name in handlers:
                         # noinspection PyBroadException
                         try:
-                            handler, group = getattr(module, name).handler
+                            for handler, group in getattr(module, name).handlers:
+                                if isinstance(handler, Handler) and isinstance(group, int):
+                                    self.add_handler(handler, group)
 
-                            if isinstance(handler, Handler) and isinstance(group, int):
-                                self.add_handler(handler, group)
+                                    log.info('[{}] [LOAD] {}("{}") in group {} from "{}"'.format(
+                                        self.session_name, type(handler).__name__, name, group, module_path))
 
-                                log.info('[{}] [LOAD] {}("{}") in group {} from "{}"'.format(
-                                    self.session_name, type(handler).__name__, name, group, module_path))
-
-                                count += 1
+                                    count += 1
                         except Exception:
                             if warn_non_existent_functions:
                                 log.warning('[{}] [LOAD] Ignoring non-existent function "{}" from "{}"'.format(
@@ -785,15 +784,14 @@ class Client(Methods, Scaffold):
                     for name in handlers:
                         # noinspection PyBroadException
                         try:
-                            handler, group = getattr(module, name).handler
+                            for handler, group in getattr(module, name).handlers:
+                                if isinstance(handler, Handler) and isinstance(group, int):
+                                    self.remove_handler(handler, group)
 
-                            if isinstance(handler, Handler) and isinstance(group, int):
-                                self.remove_handler(handler, group)
+                                    log.info('[{}] [UNLOAD] {}("{}") from group {} in "{}"'.format(
+                                        self.session_name, type(handler).__name__, name, group, module_path))
 
-                                log.info('[{}] [UNLOAD] {}("{}") from group {} in "{}"'.format(
-                                    self.session_name, type(handler).__name__, name, group, module_path))
-
-                                count -= 1
+                                    count -= 1
                         except Exception:
                             if warn_non_existent_functions:
                                 log.warning('[{}] [UNLOAD] Ignoring non-existent function "{}" from "{}"'.format(


### PR DESCRIPTION
* combination of decorators with plugins has solved

* fixing last pr: allow stackable plugin decorators even in exclude and include as well.

* counting plugins has fixed

* fix indentation

* Update client.py

* Update client.py

Co-authored-by: Dan <14043624+delivrance@users.noreply.github.com>